### PR TITLE
Add cookie based authentication for account login

### DIFF
--- a/PartyApplication/Startup.cs
+++ b/PartyApplication/Startup.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.HttpsPolicy;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -15,6 +17,7 @@ namespace PartyApplication
 {
     public class Startup
     {
+        public const string CookieScheme = "Cookies";
         public Startup(IConfiguration configuration)
         {
             Configuration = configuration;
@@ -26,6 +29,13 @@ namespace PartyApplication
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddControllersWithViews();
+
+            services.AddAuthentication(CookieScheme)
+                .AddCookie(CookieScheme, options =>
+                {
+                    options.AccessDeniedPath = "/account/denied";
+                    options.LoginPath = "/account/loginpage/";
+                });
 
             services.AddSingleton<IEventDbService>(InitializeEventClientInstanceAsync(Configuration.GetSection("EventDb")).GetAwaiter().GetResult());
             services.AddSingleton<IAccountDbService>(InitializeAccountClientInstanceAsync(Configuration.GetSection("AccountDb")).GetAwaiter().GetResult());
@@ -52,6 +62,7 @@ namespace PartyApplication
             app.UseRouting();
 
             app.UseAuthorization();
+            app.UseAuthentication();
 
             app.UseEndpoints(endpoints =>
             {

--- a/PartyApplication/Views/Shared/_Layout.cshtml
+++ b/PartyApplication/Views/Shared/_Layout.cshtml
@@ -28,10 +28,25 @@
 
             </li>
             <li>
-                @Html.ActionLink("Login", "LoginPage", "Account")
+                @if (!User.Identity.IsAuthenticated)
+                {
+                    @Html.ActionLink("Login", "LoginPage", "Account");
+                }
+                else
+                {
+                    @Html.ActionLink("Account", "GetAccount", "Account")
+                    //<a href="account/@User.Identity.Name">Account</a>
+                }
             </li>
             <li>
-                <a href="#">Placeholder</a>
+                @if (User.Identity.IsAuthenticated)
+                {
+                    @Html.ActionLink("Logout", "Logout", "Account");
+                }
+                else
+                {
+                    <a href="#">Placeholder</a>
+                }
             </li>
         </ul>
     </nav>


### PR DESCRIPTION
This change saves the login state of an individual client and alters some pages based on that.
Specifically, if you are logged in, "Login" is changed to "Account" which for now just links to GetAccount. "Placeholder" is replaced with "Logout" which logs you out.

This method of login state saving should persist through closing and opening the site both server-side and client-side.

AccountController had several changes made to accommodate this change.

For now, login state doesn't affect whether you can create events or not, this will likely require a bit of extension to what I have here.