### PR TITLE
Alter GetAccount parameters

### DIFF
--- a/PartyApplication/Controllers/AccountController.cs
+++ b/PartyApplication/Controllers/AccountController.cs
@@ -22,14 +22,12 @@ namespace PartyApplication.Controllers
         }
 
         [HttpGet]
-        [Route("account/")]
-        public async Task<ActionResult> GetAccount()
+        [Route("account/{id}")]
+        public async Task<ActionResult> GetAccount([FromRoute] String id)
         {
-            var username = HttpContext.User.Identity.Name;
-
             try
             {
-                Account result = await _accountDbService.GetAccountAsync(username);
+                Account result = await _accountDbService.GetAccountAsync(id);
                 return View(result);
             }
             catch (Exception ex) 
@@ -75,7 +73,7 @@ namespace PartyApplication.Controllers
 
                             var claims = new List<Claim>
                             {
-                                new Claim("name", user.Username),
+                                new Claim("name", user.Id),
                                 new Claim("role", role)
                             };
 

--- a/PartyApplication/Views/Shared/_Layout.cshtml
+++ b/PartyApplication/Views/Shared/_Layout.cshtml
@@ -34,8 +34,7 @@
                 }
                 else
                 {
-                    @Html.ActionLink("Account", "GetAccount", "Account")
-                    //<a href="account/@User.Identity.Name">Account</a>
+                    @Html.ActionLink("Account", "GetAccount", "Account", new { id = User.Identity.Name })
                 }
             </li>
             <li>


### PR DESCRIPTION
Reverts GetAccount so that it takes a string parameter id (given by User.Identity.Name) to show account info. On the top bar when you are logged in, the link will automatically adjust to link to your own account info.