### PR TITLE
Users must now be logged into a host account to create events. The 'b…

### DIFF
--- a/PartyApplication/Controllers/EventController.cs
+++ b/PartyApplication/Controllers/EventController.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using PartyApplication.DbServices;
 using PartyApplication.IDbServices;
+using Microsoft.AspNetCore.Authorization;
 
 namespace PartyApplication.Controllers
 {
@@ -15,6 +16,13 @@ namespace PartyApplication.Controllers
         private readonly IEventDbService _partyDbService;
 
         private readonly IAccountDbService _accountDbService;
+
+        private static class Globals
+        {
+            public static string searchedZipcode = "";
+        }
+        
+
         public EventController(IEventDbService partyDbService, IAccountDbService accountDbService)
         {
             _partyDbService = partyDbService;
@@ -25,14 +33,28 @@ namespace PartyApplication.Controllers
         [Route("parties")]
         public async Task<IActionResult> GetPartiesByZipcode([FromForm] string zipcode)
         {
+            Globals.searchedZipcode = zipcode;
 
             List<Event> events = await _partyDbService.GetPartiesAsync($"SELECT * FROM c WHERE c.zipcode = '{zipcode}'");
+
             if (events != null)
             {
                 return View("GetParties", events);
             }
             return StatusCode(StatusCodes.Status500InternalServerError);
         }
+
+
+        //This method returns the user to the list of parties that was already filtered by the zipcode they chose
+        [HttpGet]
+        [Route("parties")]
+        public async Task<IActionResult> GetSearchedParties()
+        {
+            List<Event> events = await _partyDbService.GetPartiesAsync($"SELECT * FROM c WHERE c.zipcode = '{Globals.searchedZipcode}'");
+
+            return View("GetParties", events);
+        }
+
 
         [HttpGet("{id}")]
         [Route("party/{id}")]
@@ -50,19 +72,31 @@ namespace PartyApplication.Controllers
         {
             Guid guid = Guid.NewGuid();
             party.Id = guid.ToString();
-            if (party != null)
+
+            // if user has a host account, let them create an event
+            if (User.IsInRole("Host"))
             {
+                if (party != null)
+                {
 
-                _partyDbService.AddPartyAsync(party);
+                    _partyDbService.AddPartyAsync(party);
 
-                party.TimeCreated = DateTime.UtcNow;
+                    party.TimeCreated = DateTime.UtcNow;
 
-                // TODO: once a party is found look up user by the name of the person who added it
-                // this will allow the object to be a account object
-                return View("GetParty", party);
+                    // TODO: once a party is found look up user by the name of the person who added it
+                    // this will allow the object to be a account object
+                    return View("GetParty", party);
+                }
+                return StatusCode(StatusCodes.Status500InternalServerError);
             }
-            return StatusCode(StatusCodes.Status500InternalServerError);
+
+            //otherwise redirect the non-host user back to the events page
+            else
+            {
+                return Redirect("/events");
+            }
         }
+
 
         [HttpDelete("{id}")]
         [Route("delete/{id}")]
@@ -85,7 +119,7 @@ namespace PartyApplication.Controllers
             return View();
         }
 
-
+        
 
         //
         //
@@ -125,6 +159,5 @@ namespace PartyApplication.Controllers
             List<Event> events = await _partyDbService.GetPartiesAsync($"SELECT * FROM c");
             return View("GetParties", events);
         }
-
     }
 }

--- a/PartyApplication/Views/Event/GetParty.cshtml
+++ b/PartyApplication/Views/Event/GetParty.cshtml
@@ -38,5 +38,5 @@
 </div>
 <div>
     @Html.ActionLink("Edit", "Edit", new { /* id = Model.PrimaryKey */ }) |
-    @Html.ActionLink("Back to list.", "GetParties", "Event")
+    @Html.ActionLink("Back to list.", "GetSearchedParties", "Event")
 </div>


### PR DESCRIPTION
…ack to list' button in GetParty now brings the user back to the party list sorted by the zipcode they chose instead of every party in the database.